### PR TITLE
Update no-unused-modules.js

### DIFF
--- a/src/rules/no-unused-modules.js
+++ b/src/rules/no-unused-modules.js
@@ -262,6 +262,7 @@ const prepareImportsAndExports = (srcFiles, context) => {
   });
   exportAll.forEach((value, key) => {
     value.forEach(val => {
+      if (val.includes('node_modules/')) return;
       const currentExports = exportList.get(val);
       const currentExport = currentExports.get(EXPORT_ALL_DECLARATION);
       currentExport.whereUsed.add(key);


### PR DESCRIPTION
note: just to show the issue in https://github.com/benmosher/eslint-plugin-import/pull/1660#issuecomment-858384144, I think we need to find a better way to solve it :)


it seems not related the file I provided in the previous comment in the PR, but related to re-exporting * from a dependency:


```
// src/utils/bridge
export * from "@dian/bridge";
```

when skip `node_modules/*`, it's working fine.
